### PR TITLE
Update kpath.c

### DIFF
--- a/klib/src/kpath.c
+++ b/klib/src/kpath.c
@@ -402,7 +402,7 @@ int kpath_open_write (const KPath *self)
   int ret = 0;  
   UTF8 *path = kstring_to_utf8 ((KString *)self);
   klog_debug (KLOG_CLASS, "Open '%s' for write", path);
-  ret = open ((char *)path, O_WRONLY | O_CREAT | O_TRUNC);
+  ret = open ((char *)path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR );
   free (path);
   KLOG_OUT
   return ret;


### PR DESCRIPTION
Error encountered during compilation:
error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments

Explanation:
Linux and *BSD mandate a third argument to open() when specifying O_CREAT or O_TMPFILE as a file creation flag.  This third argument specifies the file access mode, in this case user read & write.  

